### PR TITLE
replacer support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/metatexx/go-app-pkgs
 
-go 1.17
+go 1.21
+
+toolchain go1.21.6
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/maxence-charriere/go-app/v9 v9.8.0
+	github.com/maxence-charriere/go-app/v9 v9.8.1-0.20240215070438-5041bacc4ce0
 	github.com/metatexx/go-app-pkgs/mountpoint v1.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXq
 github.com/maxence-charriere/go-app/v9 v9.1.2/go.mod h1:zo0n1kh4OMKn7P+MrTUUi7QwUMU2HOfHsZ293TITtxI=
 github.com/maxence-charriere/go-app/v9 v9.8.0 h1:rDfLNvxIKXyjpRS76P45kn9Xj8IumwfoqpsEJYxfd+E=
 github.com/maxence-charriere/go-app/v9 v9.8.0/go.mod h1:gzgFoeaDuoNHw9MbJraTCKIoKtZ/SoIfOIHHn2FOffc=
+github.com/maxence-charriere/go-app/v9 v9.8.1-0.20240207075255-ff07574184f1 h1:Htz6jehcAkURpLUH1dCF2RQQSRmzJFo2E3fDx4/V/E4=
+github.com/maxence-charriere/go-app/v9 v9.8.1-0.20240207075255-ff07574184f1/go.mod h1:DILieaERyrL22gcv8vF8z9IJdCw1qKdjTkF1yzxhOu0=
+github.com/maxence-charriere/go-app/v9 v9.8.1-0.20240215070438-5041bacc4ce0 h1:WkmR8kleyg9MUKfpqc38uuZXdcjWQ/3tMfjWRtGCgHs=
+github.com/maxence-charriere/go-app/v9 v9.8.1-0.20240215070438-5041bacc4ce0/go.mod h1:DILieaERyrL22gcv8vF8z9IJdCw1qKdjTkF1yzxhOu0=
 github.com/metatexx/go-app-pkgs/mountpoint v1.0.1 h1:0dx4iIhx6ggoVTjxO/aps9vi0JzbZw3fvHPQQOKTOW8=
 github.com/metatexx/go-app-pkgs/mountpoint v1.0.1/go.mod h1:YvAetNc8lyGYmiXb/3gQzAhPCLeZsB+V89bKE6qwCZ0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Hi @oderwat, made a PR here so we can discuss directly by pointing code.

Seems like the replacer interface is not usable in its current state. Sorry about that.

When reading the code, I was wondering if you could use `func ()app.UI` rather than a component pointer. The issue here is that the first component is mounted and overridden by the other at each update, which results in the loss of the `"A"` content.